### PR TITLE
Fix transcribe endpoint

### DIFF
--- a/principal.py
+++ b/principal.py
@@ -1,7 +1,6 @@
 
 from fastapi import FastAPI, UploadFile, File
-import os
-from transcritor import converter_audio_generico, transcrever_audio
+from transcriber import transcribe_audio
 from analisador import analisar_texto
 from reporter import gerar_relatorio
 
@@ -13,18 +12,10 @@ def home():
 
 @app.post("/transcrever-avancado")
 async def transcrever_avancado(file: UploadFile = File(...)):
-    extensao = file.filename.split(".")[-1]
-    caminho_temp = f"temp_entrada.{extensao}"
-    with open(caminho_temp, "wb") as f:
-        f.write(await file.read())
-
-    caminho_convertido = converter_audio_generico(caminho_temp)
-    transcricao = transcrever_audio(caminho_convertido)
+    # Utiliza o utilitário de transcrição assíncrono
+    transcricao = await transcribe_audio(file)
     resultado_analise = analisar_texto(transcricao)
-    relatorio = gerar_relatorio(transcricao, resultado_analise)
-
-    os.remove(caminho_temp)
-    os.remove(caminho_convertido)
+    relatorio = gerar_relatorio(transcricao)
 
     return {
         "transcricao": transcricao,

--- a/transcriber.py
+++ b/transcriber.py
@@ -1,7 +1,13 @@
 import os
+from dotenv import load_dotenv
 import assemblyai as aai
 
-aai.settings.api_key = "d7f4166d1399467a95aac2d8ef4e8421"
+load_dotenv()
+API_KEY = os.getenv("ASSEMBLYAI_API_KEY")
+if not API_KEY:
+    raise ValueError("ASSEMBLYAI_API_KEY não definido nas variáveis de ambiente")
+
+aai.settings.api_key = API_KEY
 
 async def transcribe_audio(file):
     path = f"temp_{file.filename}"


### PR DESCRIPTION
## Summary
- fix advanced transcription endpoint to use working transcriber
- load AssemblyAI API key from env variables

## Testing
- `python -m py_compile principal.py transcriber.py reporter.py analisador.py app.py main.py gerar_signed_url.py`


------
https://chatgpt.com/codex/tasks/task_e_684dd74ff9b88333bd0b5dd485dc04cb